### PR TITLE
proper spelling of cornell corpus

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -4,11 +4,11 @@
 ### SPOLIN: Spontaneanation Pairs of Learnable ImprovisatioN
 
 This is the repo for the paper ["Grounding Conversations with Improvised Dialogues"]() (ACL2020). 
-SPOLIN is a collection of more than 68,000 "Yes, and" type dialogue pairs extracted from the Spontaneanation podcast by Paul F. Tompkins, the Cornell Movie Corpus, and the SubTle corpus.  
+SPOLIN is a collection of more than 68,000 "Yes, and" type dialogue pairs extracted from the Spontaneanation podcast by Paul F. Tompkins, the Cornell Movie-Dialogs Corpus, and the SubTle corpus.  
 
 
 #### Available SPOLIN versions:
-The core dataset that was used for the experiments in the paper only includes _yesands_ and non-_yesands_ from Spontaneanation and most of what is provided in those extracted from the Cornell Movie Corpus. After the submitting the paper, we continued our iterative data augmentation process, repeating another iteration with the Cornell Movie Corpus and extracting from the SubTle corpus. This expanded version is also included in this repository [here](/data). This latest version of SPOLIN was used to train the model used in our demo. 
+The core dataset that was used for the experiments in the paper only includes _yesands_ and non-_yesands_ from Spontaneanation and most of what is provided in those extracted from the Cornell Movie-Dialogs Corpus. After the submitting the paper, we continued our iterative data augmentation process, repeating another iteration with the Cornell Movie-Dialogs Corpus and extracting from the SubTle corpus. This expanded version is also included in this repository [here](/data). This latest version of SPOLIN was used to train the model used in our demo. 
 
 
 In the `data` folder, we provide two versions of the SPOLIN training set: 

--- a/data/README.md
+++ b/data/README.md
@@ -9,7 +9,7 @@
 
 **Second level keys:**
 * `spont`: shorthand for Spontaneanation
-* `cornell`: shorthand for Cornell Movie Dialogue Corpus 
+* `cornell`: shorthand for Cornell Movie-Dialogs Corpus 
 * `subtle`: (not present in `spolin-valid.json`) shorthand for  SubTle Corpus 
 
 Each second level item is a list of _yesands_ or non-_yesands_. Each item contains the following: 


### PR DESCRIPTION
Changed references to the Cornell corpus to "Cornell Movie-Dialogs Corpus" following [the original style](https://www.cs.cornell.edu/~cristian/Cornell_Movie-Dialogs_Corpus.html)